### PR TITLE
Fix reauthentication

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,7 +27,7 @@ b2.prototype.authorize = function(callback) {
 
   // Setup Request (basic authentication)
   let options = {
-    url: this.apiUrl + "/b2_authorize_account",
+    url: conf.apiUrl + "/b2_authorize_account",
     method: "GET",
     json: true,
     auth: {


### PR DESCRIPTION
First off, thanks so much for this package! I started going down this road and then found this and it works great!

The authorize account endpoint is always `https://api.backblazeb2.com/b2api/v1/b2_authorize_account`, and won't use the api endpoint returned from the auth request (something like `https://api001.backblazeb2.com/b2_authorize_account`). Thus, this should reference `conf.apiUrl` instead of `this.apiUrl` (which is set during authentication). The first auth request works because this value is initialized as `conf.apiUrl`.

This change allows you to call `authorize` multiple times and have it regenerate the auth token successfully